### PR TITLE
Refactor EventOrganizer to split database and GraphQL layer

### DIFF
--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -5,6 +5,8 @@ type Query {
     events(limit: Int!, offset: Int!): [Event!]!
     event(id: ID!): Event!
 
+    eventOrganizer(id: ID!): EventOrganizer!
+
     upcomingEvents(
         """
         If eventType is not provided, all upcoming events will be fetched.

--- a/repository/event_organizer.go
+++ b/repository/event_organizer.go
@@ -3,22 +3,13 @@ package repository
 import (
 	"context"
 	"github.com/dotkom/a3s/ent"
-	"github.com/dotkom/a3s/graph/model"
 )
 
 type EventOrganizerRepository struct {
 	Client *ent.Client
 }
 
-func transform(eo *ent.EventOrganizer) *model.EventOrganizer {
-	return &model.EventOrganizer{
-		ID:    eo.ID,
-		Name:  eo.Name,
-		Email: eo.Email,
-	}
-}
-
-func (r *EventOrganizerRepository) Create(name string, email string) (*model.EventOrganizer, error) {
+func (r *EventOrganizerRepository) Create(name string, email string) (*ent.EventOrganizer, error) {
 	ctx := context.Background()
 	eventOrganizer, err := r.Client.EventOrganizer.Create().
 		SetName(name).
@@ -27,7 +18,7 @@ func (r *EventOrganizerRepository) Create(name string, email string) (*model.Eve
 	if err != nil {
 		return nil, err
 	}
-	return transform(eventOrganizer), nil
+	return eventOrganizer, nil
 }
 
 func (r *EventOrganizerRepository) Count() (int, error) {
@@ -39,26 +30,22 @@ func (r *EventOrganizerRepository) Count() (int, error) {
 	return count, nil
 }
 
-func (r *EventOrganizerRepository) All() ([]*model.EventOrganizer, error) {
+func (r *EventOrganizerRepository) All() ([]*ent.EventOrganizer, error) {
 	ctx := context.Background()
 	eventOrganizers, err := r.Client.EventOrganizer.Query().All(ctx)
 	if err != nil {
 		return nil, err
 	}
-	result := make([]*model.EventOrganizer, len(eventOrganizers))
-	for i, eo := range eventOrganizers {
-		result[i] = transform(eo)
-	}
-	return result, nil
+	return eventOrganizers, nil
 }
 
-func (r *EventOrganizerRepository) Get(id int) (*model.EventOrganizer, error) {
+func (r *EventOrganizerRepository) Get(id int) (*ent.EventOrganizer, error) {
 	ctx := context.Background()
 	eventOrganizer, err := r.Client.EventOrganizer.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return transform(eventOrganizer), nil
+	return eventOrganizer, nil
 }
 
 func (r *EventOrganizerRepository) Delete(id int) error {

--- a/resolvers/event.resolvers.go
+++ b/resolvers/event.resolvers.go
@@ -1,1 +1,0 @@
-package resolvers

--- a/resolvers/event_organizer.mutations.go
+++ b/resolvers/event_organizer.mutations.go
@@ -6,5 +6,9 @@ import (
 )
 
 func CreateEventOrganizer(r *mutationResolver, ctx context.Context, data model.CreateEventOrganizerInput) (*model.EventOrganizer, error) {
-	return r.EventOrganizerRepository.Create(data.Name, data.Email)
+	eventOrganizer, err := r.EventOrganizerRepository.Create(data.Name, data.Email)
+	if err != nil {
+		return nil, err
+	}
+	return r.Query().EventOrganizer(ctx, eventOrganizer.ID)
 }

--- a/resolvers/event_organizer.resolvers.go
+++ b/resolvers/event_organizer.resolvers.go
@@ -1,0 +1,23 @@
+package resolvers
+
+import (
+	"context"
+	"github.com/dotkom/a3s/ent"
+	"github.com/dotkom/a3s/graph/model"
+)
+
+func transform(eo *ent.EventOrganizer) *model.EventOrganizer {
+	return &model.EventOrganizer{
+		ID:    eo.ID,
+		Name:  eo.Name,
+		Email: eo.Email,
+	}
+}
+
+func EventOrganizer(r *queryResolver, ctx context.Context, id int) (*model.EventOrganizer, error) {
+	eventOrganizer, err := r.EventOrganizerRepository.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return transform(eventOrganizer), nil
+}

--- a/resolvers/schema.resolvers.go
+++ b/resolvers/schema.resolvers.go
@@ -23,6 +23,10 @@ func (r *queryResolver) Event(ctx context.Context, id int) (*model.Event, error)
 	panic(fmt.Errorf("not implemented"))
 }
 
+func (r *queryResolver) EventOrganizer(ctx context.Context, id int) (*model.EventOrganizer, error) {
+	return EventOrganizer(r, ctx, id)
+}
+
 func (r *queryResolver) UpcomingEvents(ctx context.Context, eventType *model.EventType) ([]*model.Event, error) {
 	panic(fmt.Errorf("not implemented"))
 }


### PR DESCRIPTION
## Changelog

- Refactor EventOrganizer logic to separate Database and GraphQL layers

## Checklist

- [ ] I have added tests
- [ ] I have provided documentation
